### PR TITLE
fix : 단방향 해시함수를 양방향으로 바꿈

### DIFF
--- a/app/src/main/java/kr/nbc/momo/presentation/group/create/CreateGroupFragment.kt
+++ b/app/src/main/java/kr/nbc/momo/presentation/group/create/CreateGroupFragment.kt
@@ -22,7 +22,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import coil.load
 import com.google.android.material.bottomnavigation.BottomNavigationView
-import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
@@ -35,8 +34,7 @@ import kr.nbc.momo.presentation.group.model.CategoryModel
 import kr.nbc.momo.presentation.group.model.GroupModel
 import kr.nbc.momo.presentation.group.read.ReadGroupFragment
 import kr.nbc.momo.presentation.main.SharedViewModel
-import kr.nbc.momo.presentation.onboarding.term.TermFragment
-import kr.nbc.momo.util.toHashCode
+import kr.nbc.momo.util.encryptECB
 import java.util.Calendar
 
 @AndroidEntryPoint
@@ -207,7 +205,7 @@ class CreateGroupFragment : Fragment() {
         )
 
         val image = if (imageUri != null) imageUri.toString() else null
-        val groupId = binding.groupName.text.toString().toHashCode()
+        val groupId = binding.groupName.text.toString().encryptECB()
         val group = GroupModel(
             groupId,
             binding.groupName.text.toString(),

--- a/app/src/main/java/kr/nbc/momo/presentation/group/read/ReadGroupFragment.kt
+++ b/app/src/main/java/kr/nbc/momo/presentation/group/read/ReadGroupFragment.kt
@@ -228,7 +228,7 @@ class ReadGroupFragment : Fragment() {
             tvFirstDate.text = data.firstDate
             tvLastDate.text = data.lastDate
             tvLeaderId.text = data.leaderId
-            tvDetailCategoryList.text = data.category.developmentOccupations.joinToString().plus(", " + data.category.programingLanguage.joinToString())
+            tvDetailCategoryList.text = data.category.developmentOccupations.joinToString().plus(data.category.programingLanguage.joinToString())
 
             if (data.userList.contains(currentUser)) binding.btnJoinProject.text = "채팅방 이동"
             if (data.leaderId == currentUser) binding.btnEdit.visibility = View.VISIBLE

--- a/app/src/main/java/kr/nbc/momo/presentation/group/read/ReadGroupFragment.kt
+++ b/app/src/main/java/kr/nbc/momo/presentation/group/read/ReadGroupFragment.kt
@@ -228,7 +228,8 @@ class ReadGroupFragment : Fragment() {
             tvFirstDate.text = data.firstDate
             tvLastDate.text = data.lastDate
             tvLeaderId.text = data.leaderId
-            tvDetailCategoryList.text = data.category.developmentOccupations.joinToString().plus(data.category.programingLanguage.joinToString())
+            val categoryList = data.category.developmentOccupations + data.category.programingLanguage
+            tvDetailCategoryList.text = categoryList.joinToString()
 
             if (data.userList.contains(currentUser)) binding.btnJoinProject.text = "채팅방 이동"
             if (data.leaderId == currentUser) binding.btnEdit.visibility = View.VISIBLE

--- a/app/src/main/java/kr/nbc/momo/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/kr/nbc/momo/presentation/home/HomeFragment.kt
@@ -19,6 +19,7 @@ import kr.nbc.momo.presentation.group.create.CreateGroupFragment
 import kr.nbc.momo.presentation.group.model.GroupModel
 import kr.nbc.momo.presentation.group.read.ReadGroupFragment
 import kr.nbc.momo.presentation.main.SharedViewModel
+import kr.nbc.momo.util.decryptECB
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -78,6 +79,11 @@ class HomeFragment : Fragment() {
 
                     is UiState.Success -> {
                         val filterData = uiState.data.filter { it.lastDate >= getCurrentTime() && it.firstDate <= getCurrentTime() }
+                            .sortedBy {
+                                val decrypt = it.groupId.decryptECB()
+                                val dateTimeIndex = decrypt.lastIndexOf(" ")
+                                decrypt.substring(dateTimeIndex)
+                            }
                         homeAdapter = HomeAdapter(filterData)
                         binding.rvGroupList.adapter = homeAdapter
                         binding.rvGroupList.layoutManager = LinearLayoutManager(requireContext())

--- a/app/src/main/java/kr/nbc/momo/presentation/main/MainActivity.kt
+++ b/app/src/main/java/kr/nbc/momo/presentation/main/MainActivity.kt
@@ -56,7 +56,7 @@ class MainActivity : AppCompatActivity() {
                 }
 
                 R.id.chattingListFragment -> {
-                    val chattingListFragment = SignUpFragment()
+                    val chattingListFragment = ChattingListFragment()
                     supportFragmentManager.beginTransaction()
                         .replace(R.id.fragment_container, chattingListFragment)
                         .commit()

--- a/app/src/main/java/kr/nbc/momo/presentation/main/MainActivity.kt
+++ b/app/src/main/java/kr/nbc/momo/presentation/main/MainActivity.kt
@@ -56,7 +56,7 @@ class MainActivity : AppCompatActivity() {
                 }
 
                 R.id.chattingListFragment -> {
-                    val chattingListFragment = ChattingListFragment()
+                    val chattingListFragment = SignUpFragment()
                     supportFragmentManager.beginTransaction()
                         .replace(R.id.fragment_container, chattingListFragment)
                         .commit()


### PR DESCRIPTION
단방향 해시함수를 양방향 해시함수로 바꿨습니다
 -> 그룹아이디에 decryptECB() 확장함수를 쓰게 되면 그룹 이름과 생성날짜를 얻을 수 있습니다.
홈리사이클러뷰의 아이템을 정렬해주었습니다