### PR TITLE
Feature/clean up

### DIFF
--- a/app/src/main/java/kr/nbc/momo/data/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/kr/nbc/momo/data/repository/ChatRepositoryImpl.kt
@@ -170,22 +170,6 @@ class ChatRepositoryImpl @Inject constructor(
                         }
                     }
                 })
-/*                val groupSnapshot = chatRef.child(groupId).get().await()
-                val groupChatResponse = groupSnapshot.getValue(GroupChatResponse::class.java)
-                val groupUserResponse = groupChatResponse?.userList ?: listOf()
-
-                val lastViewChatResponse = groupChatResponse?.chatList?.last() ?: ChatResponse()
-                val newGroupUserResponse = groupUserResponse.map {
-                    if (it.userId == userId) it.copy(lastViewedChat = lastViewChatResponse) else it
-                }
-                val finalUserResponse = if (!groupUserResponse.any { it.userId == userId }) {
-                    newGroupUserResponse + GroupUserResponse(userId, userName, url, lastViewChatResponse)
-                } else groupUserResponse
-
-                val newGroupChatResponse = groupChatResponse?.copy(
-                    userList = finalUserResponse
-                )
-                chatRef.child(groupId).setValue(newGroupChatResponse).await()*/
             }
         } catch (e: Exception) {
             Log.e("repository", "Failed to update last viewed chat", e)

--- a/app/src/main/java/kr/nbc/momo/domain/repository/ChatRepository.kt
+++ b/app/src/main/java/kr/nbc/momo/domain/repository/ChatRepository.kt
@@ -16,5 +16,5 @@ interface ChatRepository {
         url: String
     )
 
-    suspend fun setLastViewedChat(groupId: String, userId: String, userName: String)
+    suspend fun setLastViewedChat(groupId: String, userId: String, userName: String, url: String)
 }

--- a/app/src/main/java/kr/nbc/momo/domain/usecase/SetLastViewedChatUseCase.kt
+++ b/app/src/main/java/kr/nbc/momo/domain/usecase/SetLastViewedChatUseCase.kt
@@ -6,7 +6,7 @@ import javax.inject.Inject
 class SetLastViewedChatUseCase @Inject constructor(
     private val chatRepository: ChatRepository
 ) {
-    suspend operator fun invoke(groupId: String, userId: String, userName: String) {
-        return chatRepository.setLastViewedChat(groupId, userId, userName)
+    suspend operator fun invoke(groupId: String, userId: String, userName: String, url: String) {
+        return chatRepository.setLastViewedChat(groupId, userId, userName, url)
     }
 }

--- a/app/src/main/java/kr/nbc/momo/presentation/chatting/chattingroom/ChattingRoomFragment.kt
+++ b/app/src/main/java/kr/nbc/momo/presentation/chatting/chattingroom/ChattingRoomFragment.kt
@@ -64,7 +64,7 @@ class ChattingRoomFragment : Fragment() {
 
     override fun onPause() {
         super.onPause()
-        sharedViewModel.setLastViewedChat(chattingListModel.groupId, currentUserId, currentUsername)
+        sharedViewModel.setLastViewedChat(chattingListModel.groupId, currentUserId, currentUsername, currentUrl)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/kr/nbc/momo/presentation/main/SharedViewModel.kt
+++ b/app/src/main/java/kr/nbc/momo/presentation/main/SharedViewModel.kt
@@ -69,9 +69,9 @@ fun updateUser(user: UserModel) {
     }
 
 
-    fun setLastViewedChat(groupId: String, userId: String, userName: String) {
+    fun setLastViewedChat(groupId: String, userId: String, userName: String, url: String) {
         viewModelScope.launch {
-            setLastViewedChatUseCase.invoke(groupId, userId, userName)
+            setLastViewedChatUseCase.invoke(groupId, userId, userName, url)
         }
     }
 


### PR DESCRIPTION
채팅 마지막확인채팅 로직 변경, 트랜잭션 이용해서 데이터 오버라이드 안되게 변경, 이제 첫 채팅 안쳐도 보기만하면 채팅방 인원에 들어감