### PR TITLE
fix : 그룹생성시 사진올리면 404 해결

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,7 @@ android {
 
     defaultConfig {
         applicationId = "kr.nbc.momo"
-        minSdk = 33
+        minSdk = 30
         targetSdk = 34
         versionCode = 4
         versionName = "1.0.2"

--- a/app/src/main/java/kr/nbc/momo/data/repository/GroupRepositoryImpl.kt
+++ b/app/src/main/java/kr/nbc/momo/data/repository/GroupRepositoryImpl.kt
@@ -59,7 +59,14 @@ class GroupRepositoryImpl @Inject constructor(
             ref.get().addOnSuccessListener {
                 val response = value?.toObject<GroupResponse>()
                 if (response != null) {
-                    trySend(response.toEntity())
+                    if (response.groupThumbnail != null) {
+                        storage.reference.child("groupImage").child(response.groupId.plus(".jpeg")).downloadUrl.addOnSuccessListener {
+                            trySend(response.toEntity())
+                        }
+                    } else {
+                        trySend(response.toEntity())
+                    }
+
                 } else {
                     trySend(GroupEntity(groupId = "error"))
                 }


### PR DESCRIPTION
그룹생성시 사진올리면 404뜨는거 해결했습니다
min sdk를 30으로 바꿨을때 문제되는부분이 없어서 30으로 변경후 올렸습니다